### PR TITLE
feat: backport MQTT enhancements (1–9) – availability, commands, JSON publish, service runner, validator, status, topic map, HA discovery extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ home_assistant:
 	ensure_discovery_on_startup: "${HA_ENSURE_DISCOVERY_ON_STARTUP}"  # true | false (default false)
 	ensure_discovery_timeout: "${HA_ENSURE_DISCOVERY_TIMEOUT}"        # seconds (default 2.0)
 
-	# Optional device-bundle behavior for modern HA
-	bundle_only_mode: "${HA_BUNDLE_ONLY_MODE}"        # true | false (default false)
+		# Optional device-bundle behavior for modern HA
+		bundle_only_mode: "${HA_BUNDLE_ONLY_MODE}"        # true | false (default false). When true:
+			# - publish_discovery_configs emits only the device bundle config and skips per-entity
+			# - ensure_discovery verifies the bundle topic only and can republish it if missing
 
 app:
 	# Optional metadata used for bundle origin info (o)
@@ -300,6 +302,17 @@ publish_discovery_configs(
 	one_time_mode=True,
 	emit_device_bundle=True,  # bundle first, then per-entity topics
 )
+
+Bundle-only mode
+
+If your HA supports device bundles and you don’t want per-entity discovery topics, set:
+
+```yaml
+home_assistant:
+	bundle_only_mode: true
+```
+
+Then a normal call to publish_discovery_configs with entities will publish only the bundle and skip per-entity configs.
 ```
 
 ### Discovery verification (optional self-heal)

--- a/examples/ha_discovery_complete_example.py
+++ b/examples/ha_discovery_complete_example.py
@@ -78,7 +78,7 @@ def main():
         name="Weather Station",
         model="WS-1000",
         manufacturer="Example Corp",
-        sw_version="0.3.2-b496354-dirty",
+        sw_version="0.3.2-fdf4b54-dirty",
         configuration_url="http://weather-station.local/config",
     )
     device = device_config  # For backward compatibility with examples below

--- a/examples/ha_discovery_complete_example.py
+++ b/examples/ha_discovery_complete_example.py
@@ -78,7 +78,7 @@ def main():
         name="Weather Station",
         model="WS-1000",
         manufacturer="Example Corp",
-        sw_version="0.3.2-370052a-dirty",
+        sw_version="0.3.2-b496354-dirty",
         configuration_url="http://weather-station.local/config",
     )
     device = device_config  # For backward compatibility with examples below

--- a/examples/simple_enhanced_discovery.py
+++ b/examples/simple_enhanced_discovery.py
@@ -38,7 +38,7 @@ def main():
         name="Smart Room Controller",
         manufacturer="Example Corp",
         model="Room-1000",
-        sw_version="0.3.2-370052a-dirty",  # Now supported!
+        sw_version="0.3.2-b496354-dirty",  # Now supported!
         configuration_url="http://192.168.1.50:8080",  # Now supported!
     )
 

--- a/examples/simple_enhanced_discovery.py
+++ b/examples/simple_enhanced_discovery.py
@@ -38,7 +38,7 @@ def main():
         name="Smart Room Controller",
         manufacturer="Example Corp",
         model="Room-1000",
-        sw_version="0.3.2-b496354-dirty",  # Now supported!
+        sw_version="0.3.2-fdf4b54-dirty",  # Now supported!
         configuration_url="http://192.168.1.50:8080",  # Now supported!
     )
 

--- a/scripts/sync_versions.py
+++ b/scripts/sync_versions.py
@@ -180,7 +180,7 @@ class VersionSync:
             # Skip binary files
             return False
 
-        # Pattern to match sw_version: "0.3.2-b496354-dirty" or sw_version="x.y.z"
+        # Pattern to match sw_version: "0.3.2-fdf4b54-dirty" or sw_version="x.y.z"
         sw_version_patterns = [
             r'(\s*sw_version:\s*)["\'][^"\']*["\']',  # YAML format
             r'(sw_version\s*=\s*)["\'][^"\']*["\']',  # Python format

--- a/scripts/sync_versions.py
+++ b/scripts/sync_versions.py
@@ -180,7 +180,7 @@ class VersionSync:
             # Skip binary files
             return False
 
-        # Pattern to match sw_version: "0.3.2-370052a-dirty" or sw_version="x.y.z"
+        # Pattern to match sw_version: "0.3.2-b496354-dirty" or sw_version="x.y.z"
         sw_version_patterns = [
             r'(\s*sw_version:\s*)["\'][^"\']*["\']',  # YAML format
             r'(sw_version\s*=\s*)["\'][^"\']*["\']',  # Python format

--- a/src/ha_mqtt_publisher/__init__.py
+++ b/src/ha_mqtt_publisher/__init__.py
@@ -3,10 +3,10 @@
 __version__ = "0.3.2"
 __author__ = "ronschaeffer"
 
-# Import main components for easy access
+# Import main components for easy access (sorted)
+from .availability import AvailabilityPublisher, install_signal_handlers
+from .commands import CommandProcessor, Executor
 from .config import Config, MQTTConfig
-
-# Import HA discovery components
 from .ha_discovery import (
     Device,
     DiscoveryManager,
@@ -14,15 +14,32 @@ from .ha_discovery import (
     StatusSensor,
     publish_discovery_configs,
 )
+from .json_publish import publish_json, publish_many
 from .publisher import MQTTPublisher
+from .service_runner import run_service_loop, run_service_once
+from .status import StatusError, StatusPayload
+from .topic_map import TopicMap
+from .validator import validate_retained
 
 __all__ = [
+    "AvailabilityPublisher",
+    "CommandProcessor",
     "Config",
     "Device",
     "DiscoveryManager",
     "Entity",
+    "Executor",
     "MQTTConfig",
     "MQTTPublisher",
+    "StatusError",
+    "StatusPayload",
     "StatusSensor",
+    "TopicMap",
+    "install_signal_handlers",
     "publish_discovery_configs",
+    "publish_json",
+    "publish_many",
+    "run_service_loop",
+    "run_service_once",
+    "validate_retained",
 ]

--- a/src/ha_mqtt_publisher/availability.py
+++ b/src/ha_mqtt_publisher/availability.py
@@ -1,0 +1,82 @@
+"""Generic availability + signal helpers for MQTT services.
+
+Lightweight utilities to publish simple online/offline presence to a chosen
+MQTT topic (retained), and to integrate graceful shutdown via signals.
+
+No Home Assistant dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+import logging
+import signal
+from types import FrameType
+
+logger = logging.getLogger(__name__)
+
+
+class AvailabilityPublisher:
+    """Publishes simple online/offline retained states to a topic.
+
+    Expects a client with a ``publish(topic, payload, qos=0, retain=False)`` method
+    (e.g., paho-mqtt client or library MQTTPublisher).
+    """
+
+    def __init__(self, mqtt_client, topic: str, qos: int = 0):
+        self._client = mqtt_client
+        self.topic = topic
+        self.qos = qos
+
+    def online(self, retain: bool = True) -> None:
+        """Publish online state.
+
+        Method name matches existing project to allow drop-in replacement.
+        """
+        try:
+            self._client.publish(self.topic, "online", qos=self.qos, retain=retain)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("availability online failed: %s", e)
+
+    def offline(self, retain: bool = True) -> None:
+        """Publish offline state."""
+        try:
+            self._client.publish(self.topic, "offline", qos=self.qos, retain=retain)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("availability offline failed: %s", e)
+
+
+class _SignalController(AbstractContextManager):
+    def __init__(self, shutdown_cb: Callable[[], None]):
+        self._shutdown_cb = shutdown_cb
+        self._orig_int = None
+        self._orig_term = None
+
+    def __enter__(self):
+        def _handler(
+            signum: int, frame: FrameType | None
+        ):  # pragma: no cover - OS signals
+            try:
+                self._shutdown_cb()
+            finally:
+                # Restore original then re-raise default behavior
+                self.__exit__(None, None, None)
+
+        self._orig_int = signal.getsignal(signal.SIGINT)
+        self._orig_term = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGINT, _handler)
+        signal.signal(signal.SIGTERM, _handler)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - OS signals
+        if self._orig_int is not None:
+            signal.signal(signal.SIGINT, self._orig_int)
+        if self._orig_term is not None:
+            signal.signal(signal.SIGTERM, self._orig_term)
+        return False
+
+
+def install_signal_handlers(shutdown_cb: Callable[[], None]) -> _SignalController:
+    """Context manager that installs SIGINT/SIGTERM handlers to call shutdown_cb."""
+    return _SignalController(shutdown_cb)

--- a/src/ha_mqtt_publisher/commands.py
+++ b/src/ha_mqtt_publisher/commands.py
@@ -1,0 +1,259 @@
+"""Generic MQTT command processing utilities.
+
+A reusable version of the CommandProcessor used in Twickenham Events, designed
+to be broker- and domain-agnostic. Handles JSON/plain payloads, acks, results,
+single-flight, cooldowns, and a lightweight registry for UI exposure.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import json
+import logging
+import threading
+import time
+from typing import Any
+import uuid
+
+logger = logging.getLogger(__name__)
+
+Executor = Callable[[dict[str, Any]], tuple[str, str, dict[str, Any]]]
+
+
+@dataclass
+class CommandProcessor:
+    client: Any  # object with publish()
+    ack_topic: str
+    result_topic: str
+    max_history: int = 128
+    retain_ack: bool = False
+    retain_result: bool = False
+    qos: int = 1
+    executors: dict[str, Executor] = field(default_factory=dict)
+    _registry_meta: dict[str, dict[str, Any]] = field(default_factory=dict)
+    _last_success_ts: dict[str, float] = field(default_factory=dict)
+    _auto_registry_topic: str | None = None
+    _recent_ids: deque[str] = field(default_factory=deque, repr=False)
+    _recent_set: set[str] = field(default_factory=set, repr=False)
+    _seq: int = 0
+    _active_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    # Registration -------------------------------------------------------------
+    def register(
+        self,
+        name: str,
+        executor: Executor,
+        *,
+        description: str | None = None,
+        args_schema: dict | None = None,
+        outcome_codes: list[str] | None = None,
+        qos_recommended: int | None = None,
+        cooldown_seconds: int | None = None,
+        requires_ai: bool | None = None,
+    ) -> None:
+        self.executors[name] = executor
+        meta = {
+            "name": name,
+            "description": description or "",
+            "args_schema": args_schema or {},
+            "outcome_codes": outcome_codes
+            or ["success", "validation_failed", "fatal_error", "busy"],
+            "qos_recommended": qos_recommended
+            if qos_recommended is not None
+            else self.qos,
+        }
+        if cooldown_seconds is not None:
+            meta["cooldown_seconds"] = cooldown_seconds
+        if requires_ai is not None:
+            meta["requires_ai"] = requires_ai
+        self._registry_meta[name] = meta
+        if self._auto_registry_topic:
+            try:  # pragma: no cover - network safety
+                self.publish_registry(self._auto_registry_topic)
+            except Exception:  # pragma: no cover
+                logger.debug("auto registry publish failed", exc_info=True)
+
+    def enable_auto_registry_publish(self, topic: str) -> None:
+        self._auto_registry_topic = topic
+
+    # Public API ---------------------------------------------------------------
+    def handle_raw(self, payload: bytes | str) -> None:
+        if isinstance(payload, bytes):
+            text = payload.decode("utf-8", errors="ignore")
+        else:
+            text = str(payload)
+        stripped = text.strip()
+        if not stripped:
+            logger.warning("empty command payload ignored")
+            return
+        if stripped.startswith("{"):
+            try:
+                data = json.loads(stripped) or {}
+            except Exception:
+                data = {"command": stripped}
+        else:
+            data = {"command": stripped}
+        self._process(data)
+
+    # Internal ----------------------------------------------------------------
+    def _next_seq(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    def _publish(self, topic: str, payload: dict[str, Any], retain: bool) -> None:
+        try:
+            self.client.publish(topic, json.dumps(payload), qos=self.qos, retain=retain)
+        except Exception as e:  # pragma: no cover
+            logger.error("command publish failed topic=%s error=%s", topic, e)
+
+    def _process(self, data: dict[str, Any]) -> None:
+        cmd = (data.get("command") or "").strip().lower()
+        if not cmd:
+            logger.warning("command with no name ignored")
+            return
+        cmd_id = (data.get("id") or "").strip() or str(uuid.uuid4())
+        if cmd_id in self._recent_set:
+            logger.info("duplicate command ignored id=%s command=%s", cmd_id, cmd)
+            return
+        self._recent_ids.append(cmd_id)
+        self._recent_set.add(cmd_id)
+        if len(self._recent_ids) > self.max_history:
+            old = self._recent_ids.popleft()
+            self._recent_set.discard(old)
+        seq = self._next_seq()
+        received_ts = self._iso_now()
+        ack = {
+            "id": cmd_id,
+            "command": cmd,
+            "received_ts": received_ts,
+            "status": "received",
+            "seq": seq,
+        }
+        self._publish(self.ack_topic, ack, retain=self.retain_ack)
+        executor = self.executors.get(cmd)
+        if not executor:
+            result = {
+                "id": cmd_id,
+                "command": cmd,
+                "completed_ts": self._iso_now(),
+                "outcome": "unknown_command",
+                "details": "No executor registered",
+                "duration_ms": 0,
+                "seq": self._next_seq(),
+            }
+            self._publish(self.result_topic, result, retain=self.retain_result)
+            return
+        # Cooldown enforcement
+        meta = self._registry_meta.get(cmd, {})
+        cd = meta.get("cooldown_seconds")
+        now = time.time()
+        if isinstance(cd, int) and cd > 0 and cmd in self._last_success_ts:
+            elapsed = now - self._last_success_ts[cmd]
+            if elapsed < cd:
+                remaining = int(cd - elapsed)
+                result = {
+                    "id": cmd_id,
+                    "command": cmd,
+                    "completed_ts": self._iso_now(),
+                    "outcome": "cooldown",
+                    "details": f"cooldown_active retry_after_s={remaining}",
+                    "retry_after_s": remaining,
+                    "duration_ms": 0,
+                    "seq": self._next_seq(),
+                }
+                self._publish(self.result_topic, result, retain=self.retain_result)
+                return
+        threading.Thread(
+            target=self._run_executor,
+            args=(cmd_id, cmd, executor, data, received_ts),
+            daemon=True,
+        ).start()
+
+    def _run_executor(
+        self,
+        cmd_id: str,
+        cmd: str,
+        executor: Executor,
+        data: dict[str, Any],
+        received_ts: str,
+    ) -> None:
+        start = time.time()
+        if not self._active_lock.acquire(blocking=False):
+            result = {
+                "id": cmd_id,
+                "command": cmd,
+                "completed_ts": self._iso_now(),
+                "outcome": "busy",
+                "details": "Another command is executing",
+                "duration_ms": 0,
+                "seq": self._next_seq(),
+            }
+            self._publish(self.result_topic, result, retain=self.retain_result)
+            return
+        try:
+            ctx = {
+                "id": cmd_id,
+                "command": cmd,
+                "requested_ts": data.get("requested_ts"),
+                "args": data.get("args") or {},
+                "raw": data,
+                "received_ts": received_ts,
+            }
+            outcome, details, extra = executor(ctx)
+        except Exception as e:  # pragma: no cover
+            logger.exception("executor failure id=%s command=%s", cmd_id, cmd)
+            outcome = "fatal_error"
+            details = str(e)
+            extra = {}
+        finally:
+            if self._active_lock.locked():
+                self._active_lock.release()
+        duration_ms = int((time.time() - start) * 1000)
+        result = {
+            "id": cmd_id,
+            "command": cmd,
+            "completed_ts": self._iso_now(),
+            "outcome": outcome,
+            "details": details,
+            "duration_ms": duration_ms,
+            "seq": self._next_seq(),
+        }
+        if extra:
+            result.update(extra)
+        self._publish(self.result_topic, result, retain=self.retain_result)
+        if outcome == "success":
+            self._last_success_ts[cmd] = start
+
+    @staticmethod
+    def _iso_now() -> str:
+        from datetime import UTC, datetime
+
+        return datetime.now(UTC).isoformat()
+
+    # Registry ----------------------------------------------------------------
+    def build_registry_payload(
+        self, *, service_name: str = "service"
+    ) -> dict[str, Any]:
+        commands = []
+        for name, meta in self._registry_meta.items():
+            entry = dict(meta)
+            if name in self._last_success_ts:
+                entry["last_success_ts"] = int(self._last_success_ts[name])
+            commands.append(entry)
+        return {
+            "service": service_name,
+            "registry_version": 1,
+            "generated_ts": self._iso_now(),
+            "commands": commands,
+        }
+
+    def publish_registry(
+        self, topic: str, *, retain: bool = True, service_name: str = "service"
+    ) -> None:
+        payload = self.build_registry_payload(service_name=service_name)
+        self._publish(topic, payload, retain=retain)
+
+
+__all__ = ["CommandProcessor", "Executor"]

--- a/src/ha_mqtt_publisher/config.py
+++ b/src/ha_mqtt_publisher/config.py
@@ -148,6 +148,54 @@ class MQTTConfig:
         )
 
     @staticmethod
+    def from_mapping(mapping: dict, *, section: str = "mqtt") -> dict:
+        """Build config from a flat or nested mapping.
+
+        Supports keys like 'mqtt.broker_url' or nested mapping under 'mqtt'.
+        """
+
+        def _get(key: str, default=None):
+            if f"{section}.{key}" in mapping:
+                return mapping.get(f"{section}.{key}")
+            if section in mapping and isinstance(mapping[section], dict):
+                return mapping[section].get(key, default)
+            return mapping.get(key, default)
+
+        auth = _get("auth") or {}
+        return MQTTConfig.build_config(
+            broker_url=_get("broker_url"),
+            broker_port=_get("broker_port"),
+            client_id=_get("client_id"),
+            security=_get("security"),
+            username=auth.get("username") or _get("username"),
+            password=auth.get("password") or _get("password"),
+            tls=_get("tls"),
+            max_retries=_get("max_retries"),
+            last_will=_get("last_will"),
+            default_qos=_get("default_qos"),
+            default_retain=_get("default_retain"),
+            logging_config=_get("logging_config"),
+        )
+
+    @staticmethod
+    def to_publisher_kwargs(config: dict) -> dict:
+        """Convert validated config dict to kwargs for MQTTPublisher."""
+        out = {
+            "broker_url": config.get("broker_url"),
+            "broker_port": config.get("broker_port"),
+            "client_id": config.get("client_id"),
+            "security": config.get("security"),
+            "auth": config.get("auth"),
+            "tls": config.get("tls"),
+            "max_retries": config.get("max_retries"),
+            "last_will": config.get("last_will"),
+            "default_qos": config.get("default_qos"),
+            "default_retain": config.get("default_retain"),
+            "logging_config": config.get("logging_config"),
+        }
+        return out
+
+    @staticmethod
     def validate_config(config: dict) -> None:
         """Validate an MQTT configuration dictionary.
 

--- a/src/ha_mqtt_publisher/ha_discovery/__init__.py
+++ b/src/ha_mqtt_publisher/ha_discovery/__init__.py
@@ -33,9 +33,11 @@ from .publisher import (
     create_sensor,
     create_status_sensor,
     ensure_discovery,
+    publish_command_buttons,
     publish_device_bundle,
     publish_device_config,
     publish_discovery_configs,
+    purge_legacy_discovery,
 )
 
 __all__ = [
@@ -64,7 +66,9 @@ __all__ = [
     "create_sensor",
     "create_status_sensor",
     "ensure_discovery",
+    "publish_command_buttons",
     "publish_device_bundle",
     "publish_device_config",
     "publish_discovery_configs",
+    "purge_legacy_discovery",
 ]

--- a/src/ha_mqtt_publisher/ha_discovery/publisher.py
+++ b/src/ha_mqtt_publisher/ha_discovery/publisher.py
@@ -463,7 +463,7 @@ def publish_device_bundle(
 
     bundle = {
         "dev": device.get_device_info(),
-        "ents": cmps,
+        "cmps": cmps,
     }
     if origin:
         bundle["o"] = origin

--- a/src/ha_mqtt_publisher/json_publish.py
+++ b/src/ha_mqtt_publisher/json_publish.py
@@ -1,0 +1,63 @@
+"""JSON publishing helpers for MQTT (generic).
+
+Provides thin helpers to consistently publish retained JSON payloads with
+optional timestamp injection and debug logging.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def publish_json(
+    client,
+    topic: str,
+    obj: dict[str, Any] | list[Any],
+    *,
+    qos: int = 0,
+    retain: bool = True,
+    ensure_ts_field: str | None = None,
+    ts_value: str | None = None,
+    debug: bool = False,
+) -> None:
+    """Publish an object as JSON.
+
+    - client: has publish(topic, payload, qos, retain)
+    - ensure_ts_field: if provided and obj is a dict, inject ts_value under this key when missing
+    - ts_value: precomputed timestamp string; if None and ensure_ts_field set, a UTC ISO timestamp is generated
+    """
+    payload_obj = obj
+    if (
+        ensure_ts_field
+        and isinstance(payload_obj, dict)
+        and ensure_ts_field not in payload_obj
+    ):
+        payload_obj = dict(payload_obj)
+        payload_obj[ensure_ts_field] = ts_value or _iso_now()
+    if debug:
+        logger.debug("publish_json topic=%s payload=%s", topic, payload_obj)
+    client.publish(topic, json.dumps(payload_obj), qos=qos, retain=retain)
+
+
+def publish_many(
+    client,
+    messages: list[tuple[str, dict[str, Any] | list[Any], int, bool]],
+    *,
+    debug: bool = False,
+) -> None:
+    """Publish many JSON messages.
+
+    messages: list of (topic, obj, qos, retain)
+    """
+    for topic, obj, qos, retain in messages:
+        publish_json(client, topic, obj, qos=qos, retain=retain, debug=debug)
+
+
+def _iso_now() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()

--- a/src/ha_mqtt_publisher/service_runner.py
+++ b/src/ha_mqtt_publisher/service_runner.py
@@ -1,0 +1,114 @@
+"""Service runner conveniences for MQTT-backed services.
+
+Provides simple helpers to run a one-shot cycle or a periodic loop with
+optional availability publishing and graceful signal handling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import signal
+import threading
+import time
+
+from .availability import AvailabilityPublisher
+
+
+def run_service_once(
+    *,
+    setup: Callable[[], None] | None = None,
+    cycle: Callable[[], None] | None = None,
+    teardown: Callable[[], None] | None = None,
+    availability: AvailabilityPublisher | None = None,
+) -> None:
+    """Run a single service cycle with optional availability and hooks.
+
+    - Calls setup() once (if provided)
+    - Marks availability online
+    - Calls cycle() once (if provided)
+    - Marks availability offline
+    - Calls teardown() (if provided)
+    """
+
+    if setup:
+        setup()
+
+    if availability:
+        availability.online()
+
+    try:
+        if cycle:
+            cycle()
+    finally:
+        if availability:
+            availability.offline()
+        if teardown:
+            teardown()
+
+
+def run_service_loop(
+    *,
+    interval_s: float,
+    on_tick: Callable[[], None],
+    availability: AvailabilityPublisher | None = None,
+    stop_event: threading.Event | None = None,
+    install_signals: bool = True,
+) -> None:
+    """Run a periodic loop calling on_tick every interval_s seconds.
+
+    - Optionally publishes availability online/offline
+    - Supports graceful shutdown via signals (SIGINT/SIGTERM) or provided stop_event
+    """
+
+    local_event: threading.Event | None = None
+
+    if stop_event is None:
+        local_event = threading.Event()
+        stop_event = local_event
+
+    # Install signal handlers to trigger stop
+    cleanup: list[Callable[[], None]] = []
+    if install_signals:
+
+        def _stop_handler(signum, frame):  # pragma: no cover - tiny glue
+            try:
+                stop_event.set()
+            except Exception:
+                pass
+
+        previous_int = signal.getsignal(signal.SIGINT)
+        previous_term = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGINT, _stop_handler)
+        signal.signal(signal.SIGTERM, _stop_handler)
+
+        def _restore():
+            try:
+                signal.signal(signal.SIGINT, previous_int)
+                signal.signal(signal.SIGTERM, previous_term)
+            except Exception:
+                pass
+
+        cleanup.append(_restore)
+
+    # Availability online
+    if availability:
+        availability.online()
+
+    try:
+        # Main loop
+        while not stop_event.is_set():
+            start = time.time()
+            on_tick()
+            # Sleep remaining time, if any
+            elapsed = time.time() - start
+            remaining = interval_s - elapsed
+            if remaining > 0:
+                stop_event.wait(remaining)
+    finally:
+        if availability:
+            availability.offline()
+        for fn in cleanup:
+            try:
+                fn()
+            except Exception:
+                pass

--- a/src/ha_mqtt_publisher/status.py
+++ b/src/ha_mqtt_publisher/status.py
@@ -1,0 +1,51 @@
+"""Status payload shaping helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass
+class StatusError:
+    type: str
+    message: str
+    when: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+@dataclass
+class StatusPayload:
+    status: str
+    event_count: int = 0
+    last_run_ts: int | None = None
+    last_run_iso: str | None = None
+    ai_enabled: bool | None = None
+    ai_error_count: int = 0
+    publish_error_count: int = 0
+    error_count: int = 0
+    errors: list[StatusError] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        # Convert nested dataclasses
+        d["errors"] = [asdict(e) for e in self.errors]
+        return d
+
+    def mark_run(self) -> None:
+        now = datetime.now(tz=UTC)
+        self.last_run_ts = int(now.timestamp())
+        self.last_run_iso = now.isoformat()
+
+    def add_error(
+        self, type: str, message: str, *, when_iso: str | None = None, **extra
+    ) -> None:
+        self.error_count += 1
+        self.errors.append(
+            StatusError(type=type, message=message, when=when_iso, extra=extra or None)
+        )
+
+    def cap_errors(self, max_items: int = 20) -> None:
+        if len(self.errors) > max_items:
+            self.errors = self.errors[-max_items:]

--- a/src/ha_mqtt_publisher/topic_map.py
+++ b/src/ha_mqtt_publisher/topic_map.py
@@ -1,0 +1,32 @@
+"""Topic conventions helper.
+
+Provides a tiny helper to derive common MQTT topics used by apps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TopicMap:
+    base: str
+
+    @property
+    def status(self) -> str:
+        return f"{self.base}/status"
+
+    @property
+    def availability(self) -> str:
+        return f"{self.base}/availability"
+
+    @property
+    def events(self) -> str:
+        return f"{self.base}/events"
+
+    @property
+    def commands(self) -> str:
+        return f"{self.base}/cmd"
+
+    def cmd(self, name: str) -> str:
+        return f"{self.commands}/{name}"

--- a/src/ha_mqtt_publisher/validator.py
+++ b/src/ha_mqtt_publisher/validator.py
@@ -1,0 +1,53 @@
+"""Validation utilities for retained topics and basic invariants."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import time
+from typing import Any
+
+
+def validate_retained(
+    client,
+    topics: list[str],
+    *,
+    timeout_s: float = 2.0,
+    on_message: Callable[[str, bytes], None] | None = None,
+) -> dict[str, Any]:
+    """Subscribe and capture retained payloads for a list of topics.
+
+    Returns a dict of topic->payload (raw bytes). Topics not seen within timeout
+    will be absent from the result.
+    """
+
+    seen: dict[str, Any] = {}
+
+    def _cb(_client, _userdata, msg):  # pragma: no cover - thin glue
+        try:
+            seen[msg.topic] = msg.payload
+            if on_message:
+                on_message(msg.topic, msg.payload)
+        except Exception:
+            pass
+
+    # Subscribe
+    for t in topics:
+        try:
+            client.subscribe(t, qos=0, callback=_cb)
+        except Exception:
+            # Best-effort
+            pass
+
+    deadline = time.time() + max(0.05, float(timeout_s))
+    while time.time() < deadline and len(seen) < len(topics):
+        time.sleep(0.05)
+
+    # Unsubscribe
+    for t in topics:
+        try:
+            if hasattr(client, "unsubscribe"):
+                client.unsubscribe(t)
+        except Exception:
+            pass
+
+    return seen


### PR DESCRIPTION
This PR backports and adds generic MQTT helpers proven in Twickenham Events into ha_mqtt_publisher.\n\nIncluded (1–9):\n1) Availability + signal handling (AvailabilityPublisher, install_signal_handlers)\n2) Generic CommandProcessor (ack/result, cooldowns, single-flight, registry)\n3) Retained JSON helpers (publish_json/publish_many with timestamp inject option)\n4) Service runner (run_service_once, run_service_loop with availability + signals)\n5) HA discovery extras: device bundle alignment, command buttons, purge legacy\n6) TopicMap conventions helper (status, availability, events, cmd/*)\n7) Retained topic validator (validate_retained with subscribe+timeout)\n8) Config conveniences (MQTTConfig.from_mapping, to_publisher_kwargs)\n9) Status payload shaping (StatusPayload/StatusError, mark_run, cap_errors)\n\nExports updated in package __init__.py.\nAll tests pass locally: 254 passed.\n\nFollow-up: optional docs/examples wiring and Twickenham Events drop-in switch-over.