### PR TITLE
Add message_handler helper

### DIFF
--- a/src/ha_mqtt_publisher/message_handler.py
+++ b/src/ha_mqtt_publisher/message_handler.py
@@ -1,0 +1,102 @@
+"""Reusable MQTT command message handler for Home Assistant automations.
+
+Moved from twickenham_events; provides handle_command_message utility that
+mirrors ack/result retained topics and normalises command handling.
+"""
+
+import json
+import time
+from typing import Any
+
+
+def handle_command_message(
+    client: Any,
+    config: Any,
+    processor: Any,
+    msg: Any,
+    ack_topic: str,
+    last_ack_topic: str,
+    result_topic: str,
+    last_result_topic: str,
+) -> None:
+    """Process an incoming MQTT message for command handling.
+
+    Mirrors last ack/result to retained topics and publishes a transient ack
+    with status busy/idle to ack_topic.
+    """
+    base = config.get("app.unique_id_prefix", "twickenham_events")
+    cmd_prefix = f"{base}/cmd/"
+
+    topic = getattr(msg, "topic", "") or ""
+    payload_bytes: bytes = getattr(msg, "payload", b"") or b""
+    text = payload_bytes.decode("utf-8", errors="ignore").strip()
+
+    # If we received a command result, mirror to retained last_result and
+    # immediately publish a final 'idle' ack (also mirror retained last_ack)
+    if topic == result_topic:
+        try:
+            result_obj = json.loads(text or "{}") if text else {}
+            try:
+                client.publish(
+                    last_result_topic, json.dumps(result_obj), qos=0, retain=True
+                )
+            except Exception:
+                pass
+            ack_payload = {
+                "status": "idle",
+                "command": "idle",
+                "id": result_obj.get("id"),
+                "completed_ts": result_obj.get("completed_ts") or time.time(),
+            }
+            client.publish(ack_topic, json.dumps(ack_payload), qos=0, retain=False)
+            try:
+                client.publish(
+                    last_ack_topic, json.dumps(ack_payload), qos=0, retain=True
+                )
+            except Exception:
+                pass
+        except Exception:
+            pass
+        return
+
+    if topic.startswith(cmd_prefix):
+        cmd_name = topic[len(cmd_prefix) :].strip().lower()
+        if text == "" or text.upper() == "PRESS":
+            try:
+                _ack = {
+                    "status": "busy",
+                    "command": cmd_name,
+                    "received_ts": time.time(),
+                }
+                client.publish(ack_topic, json.dumps(_ack), qos=0, retain=False)
+                try:
+                    client.publish(last_ack_topic, json.dumps(_ack), qos=0, retain=True)
+                except Exception:
+                    pass
+            except Exception:
+                pass
+            processor.handle_raw(cmd_name)
+            return
+        try:
+            _cmd = text
+            try:
+                _obj = json.loads(text)
+                _cmd = _obj.get("name") or _obj.get("command") or text
+            except Exception:
+                pass
+            _ack = {
+                "status": "busy",
+                "command": str(_cmd).lower(),
+                "received_ts": time.time(),
+            }
+            client.publish(ack_topic, json.dumps(_ack), qos=0, retain=False)
+            try:
+                client.publish(last_ack_topic, json.dumps(_ack), qos=0, retain=True)
+            except Exception:
+                pass
+        except Exception:
+            pass
+        processor.handle_raw(text)
+        return
+
+    processor.handle_raw(payload_bytes)

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1,0 +1,94 @@
+import json
+import types
+
+from ha_mqtt_publisher.message_handler import handle_command_message
+
+
+class DummyClient:
+    def __init__(self):
+        self.published = []
+
+    def publish(self, topic, payload, qos=0, retain=False):
+        self.published.append((topic, payload, qos, retain))
+
+
+class DummyProcessor:
+    def __init__(self):
+        self.calls = []
+
+    def handle_raw(self, data):
+        self.calls.append(data)
+
+
+def test_handle_result_message_mirrors_and_ack():
+    client = DummyClient()
+    processor = DummyProcessor()
+    cfg = {"app.unique_id_prefix": "testapp"}
+
+    msg = types.SimpleNamespace(
+        topic="test/result",
+        payload=json.dumps({"id": "123", "completed_ts": 1}).encode(),
+    )
+    handle_command_message(
+        client,
+        cfg,
+        processor,
+        msg,
+        ack_topic="test/ack",
+        last_ack_topic="test/last_ack",
+        result_topic="test/result",
+        last_result_topic="test/last_result",
+    )
+
+    # Should have mirrored last result and published an ack
+    assert any(t == "test/last_result" for t, *_ in client.published)
+    assert any(t == "test/ack" for t, *_ in client.published)
+    assert any(t == "test/last_ack" for t, *_ in client.published)
+    # Processor should not be called for a result message
+    assert processor.calls == []
+
+
+def test_handle_command_press_calls_processor():
+    client = DummyClient()
+    processor = DummyProcessor()
+    cfg = {"app.unique_id_prefix": "testapp"}
+
+    msg = types.SimpleNamespace(topic="testapp/cmd/foo", payload=b"PRESS")
+    handle_command_message(
+        client,
+        cfg,
+        processor,
+        msg,
+        ack_topic="test/ack",
+        last_ack_topic="test/last_ack",
+        result_topic="test/result",
+        last_result_topic="test/last_result",
+    )
+
+    # busy ack published
+    assert any(t == "test/ack" for t, *_ in client.published)
+    # processor.handle_raw called with 'foo'
+    assert processor.calls[-1] == "foo"
+
+
+def test_handle_command_json_calls_processor_and_lowercases():
+    client = DummyClient()
+    processor = DummyProcessor()
+    cfg = {"app.unique_id_prefix": "testapp"}
+
+    payload = json.dumps({"name": "DoThing"}).encode()
+    msg = types.SimpleNamespace(topic="testapp/cmd/doth", payload=payload)
+    handle_command_message(
+        client,
+        cfg,
+        processor,
+        msg,
+        ack_topic="test/ack",
+        last_ack_topic="test/last_ack",
+        result_topic="test/result",
+        last_result_topic="test/last_result",
+    )
+
+    assert any(t == "test/ack" for t, *_ in client.published)
+    # handler passes decoded text for JSON payloads
+    assert processor.calls[-1] == payload.decode()


### PR DESCRIPTION
Adds a reusable handle_command_message helper and unit tests. Draft for review; no behavioral changes to existing callers.